### PR TITLE
fix: guard SSE flags for arm64 build

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -6,7 +6,13 @@ endif()
 
 # FPNG stuff
 if (NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strict-aliasing -DFPNG_NO_SSE=1 -msse4.1 -mpclmul")
+    if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strict-aliasing -msse4.1 -mpclmul")
+        add_compile_definitions(FPNG_NO_SSE=0)
+    else()
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strict-aliasing")
+        add_compile_definitions(FPNG_NO_SSE=1)
+    endif()
 endif()
 
 target_include_directories(SimpleImageIOCore PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
When installing simpleimageio via pip on an Apple M1 (arm64) MacBook,
the build failed because the CMake configuration unconditionally enabled
x86-specific SSE compiler flags (`-msse4.1` and `-mpclmul`).

These flags are not supported on non-x86 systems and cause compilation
errors such as:

    clang++: error: unsupported option '-msse4.1' for target 'arm64-apple-darwin'
    clang++: error: unsupported option '-mpclmul' for target 'arm64-apple-darwin'


This PR updates `Core/CMakeLists.txt` to skip adding the x86‐specific
compiler flags `-msse4.1` and `-mpclmul` on non-x86 platforms
(e.g. macOS arm64).  
These flags caused build failures on Apple Silicon (tested with M1).

Changes
* Detect processor architecture with `CMAKE_SYSTEM_PROCESSOR`.
* Apply `-msse4.1` / `-mpclmul` only when building for x86_64/AMD64.
* Define `FPNG_NO_SSE=1` when building on other architectures.

With this change simpleimageio now builds successfully on macOS arm64.